### PR TITLE
Playlist pagination

### DIFF
--- a/src/routes/playlists.js
+++ b/src/routes/playlists.js
@@ -39,7 +39,7 @@ export default function playlistRoutes(router) {
 
   router.route('/playlists/:id')
   .get((req, res) => {
-    controller.getPlaylist(parseInt(req.query.page, 10), parseInt(req.query.limit, 10), req.user.id, req.params.id, false, req.uwave.mongo)
+    controller.getPlaylist(req.user.id, req.params.id, req.uwave.mongo)
     .then(playlist => res.status(200).json(playlist))
     .catch(e => handleError(res, e, log));
   })
@@ -89,8 +89,8 @@ export default function playlistRoutes(router) {
 
   router.route('/playlists/:id/media')
   .get((req, res) => {
-    controller.getPlaylist(parseInt(req.query.page, 10), parseInt(req.query.limit, 10), req.user.id, req.params.id, true, req.uwave.mongo)
-    .then(playlist => res.status(200).json(playlist.media))
+    controller.getPlaylistItems(parseInt(req.query.page, 10), parseInt(req.query.limit, 10), req.user.id, req.params.id, req.uwave.mongo)
+    .then(playlist => res.status(200).json(playlist))
     .catch(e => handleError(res, e, log));
   })
 


### PR DESCRIPTION
This splits the getPlaylist controller function into two simpler
functions: getPlaylist and getPlaylistItems. (The getPlaylist
function was essentially already used for two entirely different
things and controlled by a boolean flag `populate`.)

This also removes the pagination from a normal `getPlaylist` call,
because there is no longer anything to paginate (the `media` array
is replaced by a `size` number in `toPlaylistResponse`).

Getting playlist _items_ is moved into getPlaylistItems, which does
have pagination, and also returns a paginated object, which wasn't
possible before because the items would live on the `.media`
property of a playlist and paginating a property is weird.
