### PR TITLE
search: fix parsing youtube video duration using parse-iso-duration

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ioredis": "^1.9.0",
     "jsonwebtoken": "^5.0.5",
     "mongoose": "^4.1.6",
+    "parse-iso-duration": "^1.0.0",
     "ws": "^0.8.0"
   }
 }


### PR DESCRIPTION
Solves an issue with `undefined` values being accessed at the old line 42.
