### PR TITLE
playlists: sort playlist items after retrieving a page from Mongo

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
+    "array-find": "^1.0.0",
     "bluebird": "^2.10.0",
     "debug": "^2.2.0",
     "express": "^4.13.3",


### PR DESCRIPTION
MongoDB doesn't return documents in the order you specified in the
`$in` field, so we need to sort the items afterward to get the
ordering right again.
