### PR TITLE
lint: use babel-eslint parser

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,10 @@
 {
   "extends": "airbnb/base",
+  "parser": "babel-eslint",
 
   "rules": {
     "comma-dangle": [2, "never"],
-    "indent": [2, 2, { "SwitchCase": 0 }],
+    "indent": [2, 2, {"SwitchCase": 0}],
     "no-param-reassign": [2, {"props": false}]
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "./lib/api",
   "devDependencies": {
     "babel-cli": "^6.3.17",
+    "babel-eslint": "^5.0.0-beta10",
     "babel-plugin-transform-class-properties": "^6.5.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-export-extensions": "^6.5.0",


### PR DESCRIPTION
Fixes issues where the linter doesn't know how to parse a fancy ES-future feature we use.
