### PR TITLE
Fix waitlist sync around socket events

### DIFF
--- a/src/controllers/booth.js
+++ b/src/controllers/booth.js
@@ -36,7 +36,7 @@ export async function getBooth(uw) {
 
 export function skipBooth(uw, moderatorID, userID, reason) {
   uw.redis.publish('v1', createCommand('skip', { moderatorID, userID, reason }));
-  uw.redis.publish('v1p', createCommand('advance', null));
+  uw.redis.publish('v1p', createCommand('advance'));
   return Promise.resolve(true);
 }
 
@@ -55,7 +55,7 @@ export async function replaceBooth(uw, moderatorID, id) {
     moderatorID,
     userID: id
   }));
-  uw.redis.publish('v1p', createCommand('advance', null));
+  uw.redis.publish('v1p', createCommand('advance'));
   return waitlist;
 }
 


### PR DESCRIPTION
This pulls most of the advance logic into `./advance` and into a
single internal "advance" command, instead of the previous
"cycleWaitlist" and "advance" commands. Previously, the current DJ
would be added to the waitlist again, which would trigger a
waitlist update, and an "advance" command. The "advance" command
would take the first DJ from the waitlist, process the advance,
and broadcast a public "advance" command. No new waitlist update
would be triggered, so clients' waitlists would get out of sync.

This patch changes the advance() function to do the waitlist
updates, the history updates _and_ the booth updates. So now when
you call the advance() function, you can just grab the updated
waitlist at the end and it'll be consistent (save for errors...)
