### PR TITLE
Improve favourites

### DIFF
--- a/src/controllers/booth.js
+++ b/src/controllers/booth.js
@@ -96,7 +96,12 @@ export async function favorite(uw, id, playlistID, historyID) {
     playlistID
   }));
 
-  return await playlist.save();
+  await playlist.save();
+
+  return {
+    playlistSize: playlist.media.length,
+    added: [playlistItem]
+  };
 }
 
 export async function getHistory(uw, page, limit) {


### PR DESCRIPTION
- Fixes #44 by creating a new playlist item based on the properties from the history entry
- Responds with a change set similar to `createPlaylistItems` calls, to let the client know of the new playlist state
