### PR TITLE
User socket messages

### DIFF
--- a/src/sockets.js
+++ b/src/sockets.js
@@ -330,4 +330,22 @@ export default class WSServer {
       }));
     });
   }
+
+  /**
+   * Send a command to a single user.
+   *
+   * @param {Object|string} user User or user ID to send the command to.
+   * @param {string} command Command name.
+   * @param {*} data Command data.
+   */
+  sendTo(user, command, data) {
+    const userID = typeof user === 'object' ? user._id : user;
+    this.eachClient(client => {
+      if (client._id === userID) {
+        client.conn.send(JSON.stringify({
+          command, data
+        }));
+      }
+    });
+  }
 }


### PR DESCRIPTION
Adds a `.sendTo` method to push socket messages to a single user.

Possible todo: Make `.broadcast` and `.sendTo` publish an event to redis, and have another part of the socket code listen to that to do the actual socket writing. That way, if we support running multiple api-v1 processes in the future, the rest of the api-v1 code can call `.broadcast` and it'd be broadcasted to all clients connected to all processes.
