### PR TITLE
Notify clients of cycled playlists

### DIFF
--- a/src/advance.js
+++ b/src/advance.js
@@ -149,8 +149,17 @@ export default async function advance(uw, opts = {}) {
     await clearBooth(uw);
   }
 
+  const waitlist = await getWaitlist(uw);
+
+  if (next) {
+    await uw.publish('playlist:cycle', {
+      userID: next.user.id,
+      playlistID: next.playlist.id
+    });
+  }
+
   return {
     historyEntry: next,
-    waitlist: await getWaitlist(uw)
+    waitlist
   };
 }

--- a/src/sockets.js
+++ b/src/sockets.js
@@ -290,6 +290,9 @@ export default class WSServer {
         if (this.advanceTimer === null && skipIsAllowed) {
           uw.publish('advance');
         }
+      } else if (_command.command === 'playlist:cycle') {
+        const { userID, playlistID } = _command.data;
+        this.sendTo(userID, 'playlistCycle', { playlistID });
       } else if (_command.command === 'api-v1:socket:close') {
         this._close(_command.data, CLOSE_NORMAL);
       }


### PR DESCRIPTION
Depends on #48.

Sends a `playlistCycle` message to the playlist owner, so clients can update their "playing next" views etc.
