### PR TITLE
booth: accept "remove" prop in /booth/skip to remove current DJ

### DIFF
--- a/src/controllers/booth.js
+++ b/src/controllers/booth.js
@@ -38,9 +38,11 @@ export async function getCurrentDJ(uw) {
   return await uw.redis.get('booth:currentDJ');
 }
 
-export function skipBooth(uw, moderatorID, userID, reason) {
+export function skipBooth(uw, moderatorID, userID, reason, opts = {}) {
   uw.redis.publish('v1', createCommand('skip', { moderatorID, userID, reason }));
-  uw.publish('advance');
+  uw.publish('advance', {
+    remove: opts.remove === true
+  });
   return Promise.resolve(true);
 }
 

--- a/src/routes/booth.js
+++ b/src/routes/booth.js
@@ -22,14 +22,18 @@ export default function boothRoutes() {
       return res.status(403).json('you need to be logged in');
     }
 
-    if (Object.keys(req.body).length === 0) {
+    const skippingSelf = !req.body.userID && !req.body.reason ||
+      req.body.userID === req.user.id;
+    const opts = { remove: !!req.body.remove };
+
+    if (skippingSelf) {
       controller.getCurrentDJ(req.uwave)
       .then(currentDJ => {
         if (!currentDJ || currentDJ !== req.user.id) {
           return res.status(412).json('you are not currently playing');
         }
 
-        controller.skipBooth(req.uwave, null, req.user.id, null)
+        controller.skipBooth(req.uwave, null, req.user.id, null, opts)
         .then(skipped => res.status(200).json(skipped))
         .catch(e => handleError(res, e, log));
       })
@@ -43,7 +47,7 @@ export default function boothRoutes() {
         return null;
       }
 
-      controller.skipBooth(req.uwave, req.user.id, req.body.userID, req.body.reason)
+      controller.skipBooth(req.uwave, req.user.id, req.body.userID, req.body.reason, opts)
       .then(skipped => res.status(200).json(skipped))
       .catch(e => handleError(res, e, log));
     }


### PR DESCRIPTION
Like waitlist remove, but for the DJ booth. It's a bit unfortunate that it's separate, but I'm not sure that viewing the DJ as "position 0 in the waitlist" is any better. This works for now™, at least.
