### PR TITLE
Fix moving users in the waitlist

### DIFF
--- a/src/controllers/waitlist.js
+++ b/src/controllers/waitlist.js
@@ -118,6 +118,11 @@ export async function moveWaitlist(uw, moderatorID, userID, position) {
   const clampedPosition = clamp(position, 0, waitlist.length);
   const beforeID = waitlist[clampedPosition] || null;
 
+  if (beforeID === user.id) {
+    // No change.
+    return waitlist;
+  }
+
   await uw.redis.lrem('waitlist', 0, user.id);
   if (beforeID) {
     await uw.redis.linsert('waitlist', 'BEFORE', beforeID, user.id);


### PR DESCRIPTION
Earlier this endpoint just added the user to a place in the waitlist, leading to duplicates. Now it first removes and then adds the user in the right place.

Also fixes the published socket message to say "waitlistMove" instead of "waitlistAdd".
