### PR TITLE
sockets: fix crashes when reconnecting

### DIFF
--- a/src/sockets/AuthedConnection.js
+++ b/src/sockets/AuthedConnection.js
@@ -24,10 +24,16 @@ export default class AuthedConnection extends EventEmitter {
   get key() {
     return `api-v1:disconnected:${this.user.id}`;
   }
+  get messagesKey() {
+    return `api-v1:disconnected:${this.user.id}:messages`;
+  }
 
   async sendWaiting() {
-    // Queued command list starts at index 1, see LostConnection#initQueued.
-    const messages = await this.uw.redis.lrange(this.key, 1, -1);
+    const wasDisconnected = await this.uw.redis.exists(this.key);
+    if (!wasDisconnected) {
+      return;
+    }
+    const messages = await this.uw.redis.lrange(this.messagesKey, 0, -1);
     if (messages.length) {
       debug('queued', this.user.id, this.user.username, ...messages);
     } else {


### PR DESCRIPTION
Earlier LostConnections used a super hacky way to store that a
connection was lost. They added a dummy element to the "missed
messages" list for the connection, so that other places in the
code could simply check for existence of that list. However, in
some situations two LostConnections could add the dummy element to
the same list (eg. if a user had two tabs open and disconnected
both at the same time). Then the AuthedConnection would read the
list, and find one too many dummy elements.

This instead splits the "does a lost connection exist" and "what
messages did this connection miss" questions into two separate
Redis keys, which is a bit more robust.

It does use a hacky way to have more forgiving timeouts around
restarts, but it's way better than before :bow:
