### PR TITLE
Check if user has a valid playlist before joining waitlist

### DIFF
--- a/src/controllers/waitlist.js
+++ b/src/controllers/waitlist.js
@@ -25,11 +25,8 @@ async function hasValidPlaylist(uw, userID) {
   if (!active) return false;
 
   const Playlist = uw.model('Playlist');
-  return Playlist.findOne(new ObjectId(active))
-  .then(playlist => {
-    if (!playlist || !playlist.media) return false;
-    return playlist.media.length > 0;
-  });
+  const playlist = await Playlist.findById(active);
+  return playlist && playlist.size > 0;
 }
 
 export async function getWaitlist(uw) {


### PR DESCRIPTION
Fixes #57 as much as possible, will still need some changes in core to make sure the user has a valid item to play when advancing to the booth
