### PR TITLE
chat: implement mutes

### DIFF
--- a/src/controllers/chat.js
+++ b/src/controllers/chat.js
@@ -1,7 +1,17 @@
 import { createCommand } from '../sockets';
 
-export function sendChatMessage(uw, user, message) {
+const debug = require('debug')('uwave:api:controller:chat');
+
+function isMuted(uw, userID) {
+  return uw.redis.exists(`mute:${userID}`);
+}
+
+export async function sendChatMessage(uw, user, message) {
   const userID = typeof user === 'object' ? user._id : user;
+  if (await isMuted(uw, userID)) {
+    debug('muted', userID);
+    return;
+  }
   uw.publish('chat:message', {
     userID, message,
     timestamp: Date.now()

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -57,7 +57,7 @@ export default function userRoutes() {
       return res.status(422).json('time is not set');
     }
     if (req.user.id === req.params.id) {
-      return res.status(403, 'you can\'t mute yourself');
+      return res.status(403).json('you can\'t mute yourself');
     }
 
     if (typeof req.body.time !== 'number' || isNaN(req.body.time)) {
@@ -74,7 +74,7 @@ export default function userRoutes() {
       return res.status(403, 'you can\'t unmute yourself');
     }
 
-    controller.muteUser(req.uwave, req.user.id, req.params.id, 0)
+    controller.unmuteUser(req.uwave, req.user.id, req.params.id)
     .then(user => res.status(200).json(user))
     .catch(e => handleError(res, e, log));
   });

--- a/src/sockets.js
+++ b/src/sockets.js
@@ -215,6 +215,22 @@ export default class SocketServer {
       });
     },
     /**
+     * Broadcast that a user was muted in chat.
+     */
+    'chat:mute'({ moderatorID, userID, duration }) {
+      this.broadcast('chatMute', {
+        userID,
+        moderatorID,
+        expires: Date.now() + duration
+      });
+    },
+    /**
+     * Broadcast that a user was unmuted in chat.
+     */
+    'chat:unmute'({ moderatorID, userID }) {
+      this.broadcast('chatUnmute', { userID, moderatorID });
+    },
+    /**
      * Broadcast a vote for the current track.
      */
     'booth:vote'({ userID, direction }) {


### PR DESCRIPTION
Prevents muted users from sending chat messages.

Splits the old `muteUser` controller function into two separate functions that do muting and unmuting, instead of one that does both.

Publishes actions to Redis first instead of directly to the sockets.
