### PR TITLE
Add ?filter parameter to search through playlist items

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bluebird": "^2.10.0",
     "clamp": "^1.0.1",
     "debug": "^2.2.0",
+    "escape-string-regexp": "^1.0.5",
     "get-artist-title": "^0.0.2",
     "ioredis": "^1.9.0",
     "jsonwebtoken": "^5.0.5",

--- a/src/routes/playlists.js
+++ b/src/routes/playlists.js
@@ -97,11 +97,12 @@ export default function playlistRoutes() {
   });
 
   router.get('/:id/media', (req, res) => {
-    const { page, limit } = req.query;
+    const { page, limit, filter } = req.query;
     controller.getPlaylistItems(
       req.uwave,
-      parseInt(page, 10), parseInt(limit, 10),
-      req.user.id, req.params.id
+      req.user.id, req.params.id,
+      { page: parseInt(page, 10), limit: parseInt(limit, 10) },
+      filter
     )
     .then(playlist => res.status(200).json(playlist))
     .catch(e => handleError(res, e, log));


### PR DESCRIPTION
Because users will want to search for a specific song often.

A single filter text specified in `?filter=query` will be used to search playlist items' `artist` and `title` data.

This partially deals with the use case for goto-bus-stop/u-wave-core#15.
