### PR TITLE
sockets: clear flushed lost messages

### DIFF
--- a/src/sockets/AuthedConnection.js
+++ b/src/sockets/AuthedConnection.js
@@ -43,7 +43,7 @@ export default class AuthedConnection extends EventEmitter {
       const { command, data } = JSON.parse(message);
       this.send(command, data);
     });
-    await this.uw.redis.del(this.key);
+    await this.uw.redis.del(this.key, this.messagesKey);
   }
 
   onMessage(raw: string) {


### PR DESCRIPTION
Earlier queued lost messages were resent after every server restart, because they weren't cleared after being sent.
