### PR TITLE
auth: add ReCaptcha verification to user registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "parse-iso-duration": "^1.0.0",
     "random-string": "^0.1.2",
     "ratelimiter": "^2.1.2",
+    "request": "^2.70.0",
     "router": "^1.1.4",
     "try-json-parse": "^0.1.1",
     "ultron": "^1.0.2",

--- a/src/ApiV1.js
+++ b/src/ApiV1.js
@@ -71,6 +71,15 @@ export default class ApiV1 extends Router {
       );
     }
 
+    if (options.recaptcha && !options.recaptcha.secret) {
+      throw new TypeError(
+        'ReCaptcha validation is enabled, but "options.recaptcha.secret" is ' +
+        'not set. Please set "options.recaptcha.secret" to your ReCaptcha ' +
+        'secret, or disable ReCaptcha validation by setting "options.recaptcha" ' +
+        'to "false".'
+      );
+    }
+
     const router = super(options);
 
     this.uw = uw;
@@ -83,7 +92,10 @@ export default class ApiV1 extends Router {
     this
       .use(bodyParser.json())
       .use(this.attachUwaveToRequest())
-      .use(authenticator(this, { secret: options.secret }))
+      .use(authenticator(this, {
+        secret: options.secret,
+        recaptcha: options.recaptcha
+      }))
       .use(rateLimit('api-v1-http', { max: 500, duration: 60 * 1000 }));
 
     this

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,16 +18,6 @@ export function checkFields(res, obj, types) {
   return true;
 }
 
-export function handleDuplicate(res, str, fields) {
-  for (let i = 0, l = fields.length; i < l; i++) {
-    if (str.includes(fields[i])) {
-      res.status(422).json(`${fields[i]} is already in use`);
-      return true;
-    }
-  }
-  return false;
-}
-
 export function paginate(page, size, result, error = null) {
   return { page, size, result, error };
 }


### PR DESCRIPTION
Depends on #59 for no good reason.

ReCaptcha validation is opt-in, using the `recaptcha` option. Pass it an object with the RC secret to enable:

``` js
webApi({
  secret: myJWTSecret,
  recaptcha: {
    secret: myRecaptchaSecret
  }
});
```

If you don't set the `recaptcha` option, a line will be logged on every user registration :')
