### PR TITLE
sockets: add guest count, closes #99

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "bluebird": "^2.10.0",
     "body-parser": "^1.15.0",
     "clamp": "^1.0.1",
+    "debounce": "^1.0.0",
     "debug": "^2.2.0",
     "escape-string-regexp": "^1.0.5",
     "get-artist-title": "^0.0.2",

--- a/src/ApiV1.js
+++ b/src/ApiV1.js
@@ -130,6 +130,13 @@ export default class ApiV1 extends Router {
     return attachUwaveMeta(this, this.uw);
   }
 
+  /**
+   * @return Number of open guest connections.
+   */
+  getGuestCount() {
+    return this.sockets.getGuestCount();
+  }
+
   destroy() {
     this.sockets.destroy();
     this.sockets = null;

--- a/src/controllers/now.js
+++ b/src/controllers/now.js
@@ -6,9 +6,10 @@ import { getServerTime } from './server';
 
 const ObjectId = mongoose.Types.ObjectId;
 
-export async function getState(uw, id) {
+export async function getState(v1, uw, id) {
   const User = uw.model('User');
 
+  const guests = v1.getGuestCount();
   const motd = uw.getMotd();
   const playlists = getPlaylists(uw, 0, 50, id);
   const booth = getBooth(uw);
@@ -27,6 +28,7 @@ export async function getState(uw, id) {
     booth,
     user,
     users,
+    guests,
     waitlist,
     waitlistLocked,
     activePlaylist,

--- a/src/routes/now.js
+++ b/src/routes/now.js
@@ -6,15 +6,15 @@ import handleError from '../errors';
 
 const log = debug('uwave:api:v1:now');
 
-export default function nowRoute() {
+export default function nowRoute(v1) {
   return router()
     .get('/', (req, res) => {
       if (!req.user) {
         req.user = { id: null };
       }
 
-      controller.getState(req.uwave, req.user.id)
-      .then(state => res.status(200).json(state))
-      .catch(e => handleError(res, e, log));
+      controller.getState(v1, req.uwave, req.user.id)
+        .then(state => res.status(200).json(state))
+        .catch(e => handleError(res, e, log));
     });
 }


### PR DESCRIPTION
Broadcasts a `guest` command every time a guest connection is added or removed. It only sends the _number_ of connected guests, which is all you need.

Alternative would be to send `guest:join` and `guest:leave` commands. That would be nicely in line with `user:{join,leave}`. Clients would have to keep track of the number though, and we can't send any other information except "a guest joined" because we don't know anything about guests.
