### PR TITLE
read auth token from Authorization http header

### DIFF
--- a/src/middleware/authenticator.js
+++ b/src/middleware/authenticator.js
@@ -6,9 +6,18 @@ import { isBanned as isUserBanned } from '../controllers/bans';
 
 const verify = bluebird.promisify(jwt.verify);
 
+function getHeaderToken(headers) {
+  if (headers.authorization) {
+    const parts = headers.authorization.split(' ');
+    if (parts[0].toLowerCase() === 'jwt') {
+      return parts[1];
+    }
+  }
+}
+
 export default function authenticatorMiddleware({ uw }, options) {
   async function authenticator(req) {
-    const token = req.query && req.query.token;
+    const token = req.query && req.query.token || getHeaderToken(req.headers);
     if (!token) {
       return;
     }


### PR DESCRIPTION
this is what authorization headers are for. :sparkles: it also cleans up the request URLs a bit, so you can read them in browser consoles for example.

(also, in the future we might want to have oauth-style authentication, which could also use this Authorization header)
