### PR TITLE
waitlist: require an active socket connection when joining

### DIFF
--- a/src/middleware/requireActiveConnection.js
+++ b/src/middleware/requireActiveConnection.js
@@ -1,0 +1,19 @@
+import { PermissionError } from '../errors';
+
+export default function requireActiveConnection() {
+  async function isConnected(uwave, user) {
+    const onlineIDs = await uwave.redis.lrange('users', 0, -1);
+    return onlineIDs.indexOf(user.id) !== -1;
+  }
+
+  return (req, res, next) => {
+    isConnected(req.uwave, req.user)
+      .then(connected => {
+        if (!connected) {
+          throw new PermissionError('You need to be logged in and connected to do this.');
+        }
+      })
+      .then(() => next())
+      .catch(next);
+  };
+}

--- a/src/routes/waitlist.js
+++ b/src/routes/waitlist.js
@@ -2,6 +2,7 @@ import debug from 'debug';
 import createRouter from 'router';
 
 import protect from '../middleware/protect';
+import requireActiveConnection from '../middleware/requireActiveConnection';
 import * as controller from '../controllers/waitlist';
 import { checkFields } from '../utils';
 import handleError from '../errors';
@@ -18,7 +19,7 @@ export default function waitlistRoutes() {
     .catch(e => handleError(res, e, log));
   });
 
-  router.post('/', protect(), (req, res) => {
+  router.post('/', protect(), requireActiveConnection(), (req, res) => {
     if (!req.body.userID) return res.status(422).json('userID is not set');
     let _position = parseInt(req.body.position, 10);
     _position = (!isNaN(_position) ? _position : -1);


### PR DESCRIPTION
(May have to apply this to other things later. Votes and chat already require an active connection.)

This should fix most of the glitches we've had with users being in the waitlist, but not seen as "online" by üWave.
