### PR TITLE
Move items to end of playlist, fixes #115

### DIFF
--- a/src/controllers/playlists.js
+++ b/src/controllers/playlists.js
@@ -163,14 +163,22 @@ export async function removePlaylistItems(req) {
 }
 
 export async function movePlaylistItems(req) {
-  const { after, items } = req.body;
+  const { at, after, items } = req.body;
   if (!Array.isArray(items)) {
     throw new HTTPError(422, 'Expected "items" to be an array');
   }
 
   const playlist = await req.user.getPlaylist(req.params.id);
 
-  const result = await playlist.moveItems(items, { afterID: after });
+  let afterID = after;
+  if (at === 'start') {
+    afterID = -1;
+  } else if (at === 'end') {
+    const last = await playlist.getItemAt(playlist.size - 1);
+    afterID = last.id;
+  }
+
+  const result = await playlist.moveItems(items, { afterID });
   return toItemResponse(result, { url: req.fullUrl });
 }
 

--- a/src/controllers/playlists.js
+++ b/src/controllers/playlists.js
@@ -125,23 +125,32 @@ export async function getPlaylistItems(req) {
 }
 
 export async function addPlaylistItems(req) {
-  const { after, items } = req.body;
+  const { at, after, items } = req.body;
   if (!Array.isArray(items)) {
     throw new HTTPError(422, 'Expected "items" to be an array.');
   }
 
   const playlist = await req.user.getPlaylist(req.params.id);
+
+  let afterID = after;
+  if (at === 'start') {
+    afterID = -1;
+  } else if (at === 'end') {
+    const last = await playlist.getItemAt(playlist.size - 1);
+    afterID = last.id;
+  }
+
   const {
     added,
-    afterID,
+    afterID: finalAfterID,
     playlistSize,
-  } = await playlist.addItems(items, { after });
+  } = await playlist.addItems(items, { after: afterID });
 
   return toListResponse(added, {
     included: {
       media: ['media'],
     },
-    meta: { afterID, playlistSize },
+    meta: { afterID: finalAfterID, playlistSize },
   });
 }
 

--- a/src/validations.js
+++ b/src/validations.js
@@ -177,9 +177,10 @@ export const movePlaylistItems = joi.object({
     items: joi.array().required(),
     after: [
       objectID, // Insert after ID
-      joi.number().valid(-1), // Prepend
+      joi.number().valid(-1), // Old-style prepend (use at=start instead)
     ],
-  }),
+    at: joi.string().valid('start', 'end'),
+  }).xor('after', 'at'),
 });
 
 export const shufflePlaylistItems = joi.object({


### PR DESCRIPTION
Set `at=start` to move or add an item to the start of a playlist. Set `at=end` to do the same for the end of a playlist. Otherwise set `after=$itemID`.