### PR TITLE
Populate `media.media` in current booth entry.

### DIFF
--- a/src/controllers/booth.js
+++ b/src/controllers/booth.js
@@ -19,6 +19,8 @@ export async function getBoothData(uw) {
     return null;
   }
 
+  await historyEntry.populate('media.media').execPopulate();
+
   const stats = await Promise.props({
     upvotes: uw.redis.smembers('booth:upvotes'),
     downvotes: uw.redis.smembers('booth:downvotes'),


### PR DESCRIPTION
Fixes a bug introduced in #177 where /now would not respond with the media data (like sourceType/sourceID) for the current track.