### PR TITLE
Fix /booth/favorite response format.

### DIFF
--- a/src/controllers/booth.js
+++ b/src/controllers/booth.js
@@ -188,9 +188,12 @@ export async function favorite(req) {
 
   await playlist.save();
 
-  return toListResponse(playlistItem, {
+  return toListResponse([playlistItem], {
     meta: {
       playlistSize: playlist.media.length,
+    },
+    included: {
+      media: ['media'],
     },
   });
 }


### PR DESCRIPTION
Respond with an array of added items instead of a single object item. The array will always have length 1 but this is consistent with how adding songs to a playlist normally works.