### PR TITLE
Ignore incorrect JWT instead of rejecting the request

### DIFF
--- a/src/auth/JWTStrategy.js
+++ b/src/auth/JWTStrategy.js
@@ -49,16 +49,16 @@ export default class JWTStrategy extends Strategy {
     try {
       value = await jwtVerify(token, this.secret);
     } catch (e) {
-      return this.fail({ message: 'Invalid token' }, 400);
+      return this.pass();
     }
 
     if (!value) {
-      return this.fail({ message: 'Empty token' }, 400);
+      return this.pass();
     }
 
     const user = await this.getUser(value);
     if (!user) {
-      return this.fail({ message: 'User not found' }, 400);
+      return this.pass();
     }
 
     if (await user.isBanned()) {


### PR DESCRIPTION
Now if your token is expired you will not be locked out of the API
entirely.