### PR TITLE
Pass through public errors from core. 

### DIFF
--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -61,6 +61,13 @@ function serializeError(err) {
       title: 'Database error, please try again later.',
     }];
   }
+  if (err.public) {
+    return [{
+      status: err.status || 400,
+      code: err.code,
+      title: err.message,
+    }];
+  }
   return [{
     status: 500,
     code: 'unknown-error',

--- a/src/utils/beautifyDuplicateKeyError.js
+++ b/src/utils/beautifyDuplicateKeyError.js
@@ -17,9 +17,9 @@ function isDuplicateKeyError(error) {
  */
 export default function beautifyDuplicateKeyError(error) {
   if (isDuplicateKeyError(error)) {
-    if (error.message.indexOf('$username') !== -1) {
+    if (error.message.indexOf('username') !== -1) {
       return new HTTPError(400, 'That username is in use.');
-    } else if (error.message.indexOf('$email') !== -1) {
+    } else if (error.message.indexOf('email') !== -1) {
       return new HTTPError(400, 'That email address is in use.');
     }
   }


### PR DESCRIPTION
When the login code moved to -core as part of the social login preparation work, every login error (and others) were showing up as "Internal Server Error". With this patch, errors from -core marked with the `.public` property will be shown to the user as well.