### PR TITLE
Only send ping messages if socket connection is open.

### DIFF
--- a/src/sockets/AuthedConnection.js
+++ b/src/sockets/AuthedConnection.js
@@ -62,7 +62,7 @@ export default class AuthedConnection extends EventEmitter {
   }
 
   ping() {
-    if (Date.now() - this.lastMessage > 5000) {
+    if (Date.now() - this.lastMessage > 5000 && this.socket.readyState === WebSocket.OPEN) {
       this.socket.send('-');
       this.lastMessage = Date.now();
     }


### PR DESCRIPTION
Should fix the rare "not opened" crash.