### PR TITLE
Separate socket server from the HTTP API.

### DIFF
--- a/dev/u-wave-api-dev-server
+++ b/dev/u-wave-api-dev-server
@@ -15,6 +15,20 @@ const express = require('express');
 const config = require('./dev-server-config.json');
 const mailDebug = require('debug')('uwave:mail');
 
+const testTransport = {
+  name: 'test',
+  version: '0.0.0',
+  send(mail, callback) {
+    mail.message.createReadStream().pipe(concat((message) => {
+      mailDebug(mail.message.getEnvelope().to, message.toString('utf8'));
+      callback(null, {
+        envelope: mail.message.getEnvelope(),
+        messageId: mail.message.messageId()
+      });
+    }));
+  }
+};
+
 function tryRequire(file, message) {
   try {
     // eslint-disable-next-line import/no-dynamic-require
@@ -44,9 +58,9 @@ function loadDevModules() {
     'u-wave-core/src/index.js',
     'Could not find the u-wave core module. Did you run `npm link u-wave-core`?'
   );
-  const createWebApi = require('../src').default;
+  const { createHttpApi, createSocketServer } = require('../src');
 
-  return { uwave, createWebApi };
+  return { uwave, createHttpApi, createSocketServer };
 }
 
 function loadProdModules() {
@@ -54,9 +68,9 @@ function loadProdModules() {
     'u-wave-core',
     'Could not find the u-wave core module. Did you run `npm link u-wave-core`?'
   );
-  const createWebApi = require('../');
+  const { createHttpApi, createSocketServer } = require('../');
 
-  return { uwave, createWebApi };
+  return { uwave, createHttpApi, createSocketServer };
 }
 
 /**
@@ -68,7 +82,8 @@ function start() {
 
   const {
     uwave,
-    createWebApi
+    createHttpApi,
+    createSocketServer,
   } = watch ? loadDevModules() : loadProdModules();
 
   const uw = uwave(config);
@@ -92,26 +107,19 @@ function start() {
   app.set('json spaces', 2);
 
   const apiUrl = '/api';
+  const secret = Buffer.from('none', 'utf8');
 
-  app.use(apiUrl, createWebApi(uw, {
+  app.use(apiUrl, createHttpApi(uw, {
     recaptcha: { secret: recaptchaTestKeys.secret },
-    server,
-    secret: Buffer.from('none', 'utf8'),
+    secret,
     auth: config.auth,
-    mailTransport: {
-      name: 'test',
-      version: '0.0.0',
-      send(mail, callback) {
-        mail.message.createReadStream().pipe(concat((message) => {
-          mailDebug(mail.message.getEnvelope().to, message.toString('utf8'));
-          callback(null, {
-            envelope: mail.message.getEnvelope(),
-            messageId: mail.message.messageId()
-          });
-        }));
-      }
-    }
+    mailTransport: testTransport,
   }));
+
+  createSocketServer(uw, {
+    server,
+    secret,
+  });
 
   return app;
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,7 @@ export default {
   input: 'src/index.js',
   output: [{
     file: pkg.main,
-    exports: 'default',
+    exports: 'named',
     format: 'cjs',
     sourcemap: true,
   }, {

--- a/src/AuthRegistry.js
+++ b/src/AuthRegistry.js
@@ -1,0 +1,29 @@
+import crypto from 'crypto';
+import { promisify } from 'util';
+
+const randomBytes = promisify(crypto.randomBytes);
+
+export default class AuthRegistry {
+  constructor(redis) {
+    this.redis = redis;
+  }
+
+  async createAuthToken(user) {
+    const token = (await randomBytes(64)).toString('hex');
+    await this.redis.set(`http-api:socketAuth:${token}`, user.id, 'EX', 60);
+    return token;
+  }
+
+  async getTokenUser(token) {
+    if (token.length !== 128) {
+      throw new Error('Invalid token');
+    }
+    const [userID] = await this.redis
+      .multi()
+      .get(`http-api:socketAuth:${token}`)
+      .del(`http-api:socketAuth:${token}`)
+      .exec();
+
+    return userID;
+  }
+}

--- a/src/SocketServer.js
+++ b/src/SocketServer.js
@@ -566,7 +566,7 @@ export default class SocketServer {
 
     const lastGuestCount = await this.getGuestCount();
     if (guests !== lastGuestCount) {
-      await redis.set('http-api:guests', guests)
+      await redis.set('http-api:guests', guests);
       this.broadcast('guests', guests);
     }
   }, ms('2 seconds'));

--- a/src/controllers/authenticate.js
+++ b/src/controllers/authenticate.js
@@ -43,7 +43,7 @@ export async function refreshSession(res, api, user, options) {
     { expiresIn: '31d' },
   );
 
-  const socketToken = await api.sockets.createAuthToken(user);
+  const socketToken = await api.authRegistry.createAuthToken(user);
 
   if (options.session === 'cookie') {
     const serialized = cookie.serialize('uwsession', token, {
@@ -112,8 +112,9 @@ export async function socialLoginCallback(options, req, res) {
 }
 
 export async function getSocketToken(req) {
-  const { sockets } = req.uwaveHttp;
-  const socketToken = await sockets.createAuthToken(req.user);
+  const { authRegistry } = req.uwaveHttp;
+
+  const socketToken = await authRegistry.createAuthToken(req.user);
   return toItemResponse({ socketToken }, {
     url: req.fullUrl,
   });

--- a/src/controllers/now.js
+++ b/src/controllers/now.js
@@ -18,6 +18,12 @@ async function getFirstItem(user, activePlaylist) {
   return null;
 }
 
+function toInt(str) {
+  if (typeof str !== 'string') return 0;
+  if (!/^\d+$/.test(str)) return 0;
+  return parseInt(str, 10);
+}
+
 // eslint-disable-next-line import/prefer-default-export
 export async function getState(req) {
   const uw = req.uwave;
@@ -63,10 +69,4 @@ export async function getState(req) {
   }
 
   return state;
-}
-
-function toInt(str) {
-  if (typeof str !== 'string') return 0;
-  if (!/^\d+$/.test(str)) return 0;
-  return parseInt(str, 10);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,9 @@
 import UwaveHttpApi from './HttpApi';
+import UwaveSocketServer from './SocketServer';
 
-export default function createHttpApi(uw, opts) {
+export function createHttpApi(uw, opts) {
   return new UwaveHttpApi(uw, opts);
 }
-
-createHttpApi.HttpApi = UwaveHttpApi;
-
-// Backwards compat?
-createHttpApi.V1 = UwaveHttpApi;
-createHttpApi.ApiV1 = UwaveHttpApi;
+export function createSocketServer(uw, opts) {
+  return new UwaveSocketServer(uw, opts);
+}


### PR DESCRIPTION
With this patch the HttpApi class no longer handles the socket server. Instead users have to instantiate it manually. This actually makes the API _less_ weird; previously you had to pass a Node core HTTP server instance to the middleware creation function, essentially a circular dependency. Now you can add the middleware to the express server, then get the HTTP server instance from the express server and pass it to the socket server function.

All communication between the HTTP API and the socket server goes through Redis messages now. The only remaining thing to migrate was the temporary auth tokens the socket server uses; they were already stored in Redis but the authentication routes used API methods from the socket server object. Now the routes don't need access to the socket server object anymore.

It needs more work on the u-wave-core side, but this is one step to allowing the socket server to run in its own process. That would be real neat because we could do server updates (if the socket server was not changed, which is true a good chunk of the time) without everyone's chat connections dying :)