### PR TITLE
Fix password reset validation.

### DIFF
--- a/src/validations.js
+++ b/src/validations.js
@@ -49,8 +49,10 @@ export const requestPasswordReset = joi.object({
 });
 
 export const passwordReset = joi.object({
+  params: joi.object({
+    reset: joi.string().required(),
+  }),
   body: joi.object({
-    email: userEmail.required(),
     password: userPassword.required(),
   }),
 });


### PR DESCRIPTION
The `email` is not sent here, but the password reset token is in the URL.